### PR TITLE
Test parse "false" value after encode-decode

### DIFF
--- a/tests/parse_boolean_false.phpt
+++ b/tests/parse_boolean_false.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Protocol Buffers parse boolean false value
+--SKIPIF--
+<?php require 'skipif.inc' ?>
+--FILE--
+<?php
+require 'Foo.php';
+
+$expected = new Foo();
+
+$expected->setBoolField(false);
+
+$tmp = new Foo();
+$tmp->parseFromString(base64_decode('aAA='));
+
+$actual = new Foo();
+$actual->parseFromString($tmp->serializeToString());
+
+var_dump($expected == $actual);
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
Add failed test parsing "false" value after encode-decode become "true"