### PR TITLE
looping debug fixed

### DIFF
--- a/protobuf.c
+++ b/protobuf.c
@@ -798,7 +798,8 @@ static int pb_assign_value(zval *this, zval *dst, zval *src, zend_ulong field_nu
 		goto fail2;
 	}
 
-	*dst = tmp;
+	//*dst = tmp;
+	ZVAL_COPY(dst, &tmp);
 
 	zval_ptr_dtor(&field_descriptors);
 	return 0;


### PR DESCRIPTION
message BidResponse
{
    required string id = 1; // ID of the bid request.
    optional string id1 = 2; // ID of the bid request.
    optional string cur = 66; // Currency of bid, currently always USD
}


$bidresponse = new BidResponse();
var_dump($bidresponse->setId("1"));
//var_dump($bidresponse->setId1("2"));
var_dump($bidresponse->setCur("3"));
try {
    $data = $bidresponse->serializeToString();
    var_dump($data);
} catch (Exception $ex) {
    echo $ex->getMessage();
}

when run this code, program will coredump, fix this bug